### PR TITLE
INTERLOK-4624: Updates to producers for health-check endpoint improve…

### DIFF
--- a/interlok-jms3-common/src/main/java/com/adaptris/core/jms3/DefinedJmsProducer.java
+++ b/interlok-jms3-common/src/main/java/com/adaptris/core/jms3/DefinedJmsProducer.java
@@ -47,7 +47,7 @@ public abstract class DefinedJmsProducer extends JmsProducerImpl {
     super();
   }
 
-  public void produce(AdaptrisMessage msg, String destination) throws ProduceException {
+  public void doProduce(AdaptrisMessage msg, String destination) throws ProduceException {
     try {
       setupSession(msg);
       Destination replyTo = null;
@@ -99,7 +99,7 @@ public abstract class DefinedJmsProducer extends JmsProducerImpl {
     log.info("msg produced to destination [{}]", destination);
   }
 
-  public AdaptrisMessage request(AdaptrisMessage msg, String dest, long timeout) throws ProduceException {
+  public AdaptrisMessage doRequest(AdaptrisMessage msg, String dest, long timeout) throws ProduceException {
 
     AdaptrisMessage translatedReply = defaultIfNull(getMessageFactory()).newMessage();
     Destination replyTo = null;

--- a/interlok-jms3-common/src/main/java/com/adaptris/core/jms3/JmsAsyncProducer.java
+++ b/interlok-jms3-common/src/main/java/com/adaptris/core/jms3/JmsAsyncProducer.java
@@ -50,7 +50,7 @@ public class JmsAsyncProducer extends JmsProducer {
   }
   
   @Override
-  protected void produce(AdaptrisMessage msg, JmsDestination jmsDest) throws JMSException, CoreException {
+  protected void doProduce(AdaptrisMessage msg, JmsDestination jmsDest) throws JMSException, CoreException {
     try {
       setupSession(msg);
       Message jmsMsg = translate(msg, jmsDest.getReplyToDestination());

--- a/interlok-jms3-common/src/main/java/com/adaptris/core/jms3/JmsProducer.java
+++ b/interlok-jms3-common/src/main/java/com/adaptris/core/jms3/JmsProducer.java
@@ -95,12 +95,12 @@ public class JmsProducer extends JmsProducerImpl {
     super.prepare();
   }
 
-  public void produce(AdaptrisMessage msg, String dest) throws ProduceException {
+  public void doProduce(AdaptrisMessage msg, String dest) throws ProduceException {
     try {
       setupSession(msg);
       JmsDestination target = buildDestination(dest, msg, false);
       Args.notNull(target, "destination");
-      produce(msg, target);
+      doProduce(msg, target);
       commit();
     } catch (Exception e) {
       rollback();
@@ -109,7 +109,7 @@ public class JmsProducer extends JmsProducerImpl {
     }
   }
 
-  protected void produce(AdaptrisMessage msg, JmsDestination jmsDest)
+  protected void doProduce(AdaptrisMessage msg, JmsDestination jmsDest)
       throws JMSException, CoreException {
     setupSession(msg);
     Message jmsMsg = translate(msg, jmsDest.getReplyToDestination());
@@ -125,7 +125,7 @@ public class JmsProducer extends JmsProducerImpl {
     log.info("msg produced to destination [{}]", jmsDest);
   }
 
-  public AdaptrisMessage request(AdaptrisMessage msg, String dest, long timeout) throws ProduceException {
+  public AdaptrisMessage doRequest(AdaptrisMessage msg, String dest, long timeout) throws ProduceException {
 
     AdaptrisMessage translatedReply = defaultIfNull(getMessageFactory()).newMessage();
     Destination replyTo = null;
@@ -136,7 +136,7 @@ public class JmsProducer extends JmsProducerImpl {
       replyTo = target.getReplyToDestination();
       // Listen for the reply.
       receiver = currentSession().createConsumer(replyTo);
-      produce(msg, target);
+      doProduce(msg, target);
       translatedReply = waitForReply(receiver, timeout);
       // BUG#915
       commit();
@@ -225,12 +225,7 @@ public class JmsProducer extends JmsProducerImpl {
 
   @Override
   public AdaptrisMessage request(AdaptrisMessage msg, long timeout) throws ProduceException {
-    return request(msg, endpoint(msg), timeout);
-  }
-
-  @Override
-  public void produce(AdaptrisMessage msg) throws ProduceException {
-    produce(msg, endpoint(msg));
+    return doRequest(msg, endpoint(msg), timeout);
   }
 
   @Override

--- a/interlok-jms3-common/src/main/java/com/adaptris/core/jms3/PasProducer.java
+++ b/interlok-jms3-common/src/main/java/com/adaptris/core/jms3/PasProducer.java
@@ -126,16 +126,6 @@ public class PasProducer extends DefinedJmsProducer {
   }
 
   @Override
-  public AdaptrisMessage request(AdaptrisMessage msg, long timeout) throws ProduceException {
-    return request(msg, endpoint(msg), timeout);
-  }
-
-  @Override
-  public void produce(AdaptrisMessage msg) throws ProduceException {
-    produce(msg, endpoint(msg));
-  }
-
-  @Override
   public String endpoint(AdaptrisMessage msg) throws ProduceException {
     return msg.resolve(getTopic());
   }

--- a/interlok-jms3-common/src/main/java/com/adaptris/core/jms3/PtpProducer.java
+++ b/interlok-jms3-common/src/main/java/com/adaptris/core/jms3/PtpProducer.java
@@ -128,16 +128,6 @@ public class PtpProducer extends DefinedJmsProducer {
   }
 
   @Override
-  public AdaptrisMessage request(AdaptrisMessage msg, long timeout) throws ProduceException {
-    return request(msg, endpoint(msg), timeout);
-  }
-
-  @Override
-  public void produce(AdaptrisMessage msg) throws ProduceException {
-    produce(msg, endpoint(msg));
-  }
-
-  @Override
   public String endpoint(AdaptrisMessage msg) throws ProduceException {
     return msg.resolve(getQueue());
   }

--- a/interlok-jms3-common/src/test/java/com/adaptris/core/jms3/JmsAsyncProducerTest.java
+++ b/interlok-jms3-common/src/test/java/com/adaptris/core/jms3/JmsAsyncProducerTest.java
@@ -125,7 +125,7 @@ public class JmsAsyncProducerTest
       .when(mockMessageProducer).send(any(), eq(mockMessage), any(CompletionListener.class));
 
     try {
-      producer.produce(adaptrisMessage, mockJmsDestination);
+      producer.doProduce(adaptrisMessage, mockJmsDestination);
       fail("Jms producer should have throw an exception on send()");
     } catch (Throwable t) {
       // expected;
@@ -134,7 +134,7 @@ public class JmsAsyncProducerTest
 
   @Test
   public void testSendPerMessageProperties() throws Exception {
-    producer.produce(adaptrisMessage, mockJmsDestination);
+    producer.doProduce(adaptrisMessage, mockJmsDestination);
 
     verify(mockMessageProducer).send(any(), eq(mockMessage), any(int.class), any(int.class), any(long.class), any(CompletionListener.class));
   }
@@ -142,7 +142,7 @@ public class JmsAsyncProducerTest
   @Test
   public void testSendNotPerMessageProperties() throws Exception {
     producer.setPerMessageProperties(false);
-    producer.produce(adaptrisMessage, mockJmsDestination);
+    producer.doProduce(adaptrisMessage, mockJmsDestination);
 
     verify(mockMessageProducer).send(any(), eq(mockMessage), any(JmsAsyncProducerEventHandler.class));
   }
@@ -150,7 +150,7 @@ public class JmsAsyncProducerTest
   @Test
   public void testCaptureOutgoingMessageProperties() throws Exception {
     producer.setCaptureOutgoingMessageDetails(true);
-    producer.produce(adaptrisMessage, mockJmsDestination);
+    producer.doProduce(adaptrisMessage, mockJmsDestination);
 
     verify(mockMessage).getJMSMessageID();
     verify(mockMessage).getJMSType();
@@ -161,7 +161,7 @@ public class JmsAsyncProducerTest
   @Test
   public void testNotCaptureOutgoingMessageProperties() throws Exception {
     producer.setCaptureOutgoingMessageDetails(false);
-    producer.produce(adaptrisMessage, mockJmsDestination);
+    producer.doProduce(adaptrisMessage, mockJmsDestination);
 
     verify(mockMessage, times(0)).getJMSMessageID();
     verify(mockMessage, times(0)).getJMSType();
@@ -206,7 +206,7 @@ public class JmsAsyncProducerTest
         .when(mockMessageProducer).send(any(), any(), any());
     try {
       producer.setPerMessageProperties(false);
-      producer.produce(adaptrisMessage, mockJmsDestination);
+      producer.doProduce(adaptrisMessage, mockJmsDestination);
       fail("Should throw produce exception");
     } catch (ProduceException ex) {
       // expected

--- a/interlok-jms3-common/src/test/java/com/adaptris/core/jms3/MockProducer.java
+++ b/interlok-jms3-common/src/test/java/com/adaptris/core/jms3/MockProducer.java
@@ -21,29 +21,19 @@ public class MockProducer extends DefinedJmsProducer {
     throw new ProduceException();
   }
 
-  @Override
+    @Override
+    public AdaptrisMessage doRequest(AdaptrisMessage msg, String dest, long timeout) throws ProduceException {
+        throw new ProduceException();
+    }
+
+    @Override
   public Destination createTemporaryDestination() throws JMSException {
     throw new JMSException("NO!");
   }
 
   @Override
-  public AdaptrisMessage request(AdaptrisMessage msg) throws ProduceException {
-    throw new ProduceException();
-  }
-
-  @Override
-  public void produce(AdaptrisMessage msg) throws ProduceException {
-    throw new ProduceException();
-  }
-
-  @Override
   public String endpoint(AdaptrisMessage msg) throws ProduceException {
     return null;
-  }
-
-  @Override
-  public AdaptrisMessage request(AdaptrisMessage msg, long timeout) throws ProduceException {
-    throw new ProduceException();
   }
 
   @Override


### PR DESCRIPTION
…e to connection errors

## Motivation

https://telusagriculture.atlassian.net/browse/INTERLOK-4624

## Modification

Added
- ChannelRestartErrorHandler
- ExceptionMatchers
- Updated Channel to return StoppedState if unavailable

See write up here: https://adaptris.atlassian.net/wiki/spaces/~153020547/pages/5722931220/Interlok+Channel+Unavailable+Health+Check

## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [x] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [ ] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [ ] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [ ] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [ ] Checked that new 3rd party dependencies are appropriately licensed
- [x] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [x] Added unit tests or modified existing tests to cover new code paths
- [x] Tested new/updated components in the UI and at runtime in an Interlok instance
- [ ] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [ ] Checked that javadoc generation doesn't report errors
- [ ] Checked the display of the component in the UI
- [ ] Remove any config/license annotations
- [ ] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

## Result

What's the end result for the user

## Testing
Follow steps here:
https://adaptris.atlassian.net/wiki/spaces/~153020547/pages/5722931220/Interlok+Channel+Unavailable+Health+Check
